### PR TITLE
add unittest.main() to run tests

### DIFF
--- a/logic/test_logic.py
+++ b/logic/test_logic.py
@@ -33,3 +33,6 @@ class TestLogic(unittest.TestCase):
 
     def testSqrt(self):
         self.assertEqual(sqrt(5), 5)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
tests aren't being ran because:
if __name__ == '__main__': unittest.main()
was not added to the foot of the script. whoopsie!

tests _will fail_, but they will run