### PR TITLE
add main.py entry point and wrap GUI in run() function

### DIFF
--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -1,15 +1,5 @@
 import tkinter as tk
-
-import importlib.util
-import sys
-
-file_path = "/Users/tyler/OneDrive/Desktop/GitHub Repos/Quinary_Calculator/logic/logic.py"
-module_name = "logic"
-
-spec = importlib.util.spec_from_file_location(module_name, file_path)
-logic = importlib.util.module_from_spec(spec)
-sys.modules[module_name] = logic
-spec.loader.exec_module(logic)
+from logic import logic
 
 global fieldText
 global symbol
@@ -17,9 +7,7 @@ global num1
 global num2
 global quin
 
-
 fieldText = ""
-
 symbol = ""
 num1 = ""
 num2 = ""
@@ -50,8 +38,6 @@ def calculate():
     elif(symbol == "*"):
         addToField(str(logic.multiply(int(num1), int(num2))))
         print(result)
-    
-    
 
 def clear():
     global fieldText
@@ -131,60 +117,57 @@ def buttonPressToggle():
     elif quin == False:
         addToField(str(logic.convert_to_quinary(int(num1))))
         quin = True
-    
-    
 
-window =  tk.Tk()
-window.geometry("400x400")
-window['background'] = "black"
-field=tk.Text(window, height=2, width=21, font=("Times New Roman", 20))
-field.grid(row=1, column = 1, columnspan=5)
+def run():
+    global field
+    window =  tk.Tk()
+    window.geometry("400x400")
+    window['background'] = "black"
+    field=tk.Text(window, height=2, width=21, font=("Times New Roman", 20))
+    field.grid(row=1, column = 1, columnspan=5)
 
+    #Number Buttons
+    btn0 = tk.Button(window, text="0", command=lambda: addToField(0), width = 5, font = ("Times New Roman", 14))
+    btn0.grid(row=2, column = 1, pady = 10)
 
-#Number Buttons
+    btn1 = tk.Button(window, text="1", command=lambda: addToField(1), width = 5, font = ("Times New Roman", 14))
+    btn1.grid(row=2, column = 2, pady = 10)
 
-btn0 = tk.Button(window, text="0", command=lambda: addToField(0), width = 5, font = ("Times New Roman", 14))
-btn0.grid(row=2, column = 1, pady = 10)
+    btn2 = tk.Button(window, text="2", command=lambda: addToField(2), width = 5, font = ("Times New Roman", 14))
+    btn2.grid(row=2, column = 3, pady = 10)
 
-btn1 = tk.Button(window, text="1", command=lambda: addToField(1), width = 5, font = ("Times New Roman", 14))
-btn1.grid(row=2, column = 2, pady = 10)
+    btn3 = tk.Button(window, text="3", command=lambda: addToField(3), width = 5, font = ("Times New Roman", 14))
+    btn3.grid(row=2, column = 4, pady = 10)
 
-btn2 = tk.Button(window, text="2", command=lambda: addToField(2), width = 5, font = ("Times New Roman", 14))
-btn2.grid(row=2, column = 3, pady = 10)
+    btn4 = tk.Button(window, text="4", command=lambda: addToField(4), width = 5, font = ("Times New Roman", 14))
+    btn4.grid(row=2, column = 5, pady = 10)
 
-btn3 = tk.Button(window, text="3", command=lambda: addToField(3), width = 5, font = ("Times New Roman", 14))
-btn3.grid(row=2, column = 4, pady = 10)
+    #Operations Buttons
+    btnDiv = tk.Button(window, text="/", command=lambda: buttonPressDiv(), width = 5, font = ("Times New Roman", 14))
+    btnDiv.grid(row=3, column = 4, pady = 10)
 
-btn4 = tk.Button(window, text="4", command=lambda: addToField(4), width = 5, font = ("Times New Roman", 14))
-btn4.grid(row=2, column = 5, pady = 10)
+    btnMult = tk.Button(window, text="*", command=lambda: buttonPressMult(), width = 5, font = ("Times New Roman", 14))
+    btnMult.grid(row=3, column = 3, pady = 10)
 
-#Operations Buttons
+    btnAdd = tk.Button(window, text="+", command=lambda: buttonPressAdd(), width = 5, font = ("Times New Roman", 14))
+    btnAdd.grid(row=3, column = 1, pady = 10)
 
-btnDiv = tk.Button(window, text="/", command=lambda: buttonPressDiv(), width = 5, font = ("Times New Roman", 14))
-btnDiv.grid(row=3, column = 4, pady = 10)
+    btnSub = tk.Button(window, text="-", command=lambda: buttonPressSub(), width = 5, font = ("Times New Roman", 14))
+    btnSub.grid(row=3, column = 2, pady = 10)
 
-btnMult = tk.Button(window, text="*", command=lambda: buttonPressMult(), width = 5, font = ("Times New Roman", 14))
-btnMult.grid(row=3, column = 3, pady = 10)
+    btnClr = tk.Button(window, text="Clear", command=lambda: clear(), width = 5, font = ("Times New Roman", 14))
+    btnClr.grid(row=3, column = 5, pady = 10)
 
-btnAdd = tk.Button(window, text="+", command=lambda: buttonPressAdd(), width = 5, font = ("Times New Roman", 14))
-btnAdd.grid(row=3, column = 1, pady = 10)
+    btnTog = tk.Button(window, text="Tog", command=lambda: buttonPressToggle() , width = 5, font = ("Times New Roman", 14))
+    btnTog.grid(row=4, column = 3, pady = 10)
 
-btnSub = tk.Button(window, text="-", command=lambda: buttonPressSub(), width = 5, font = ("Times New Roman", 14))
-btnSub.grid(row=3, column = 2, pady = 10)
+    btnSqrt = tk.Button(window, text="sqrt", command=lambda: buttonPressSqrt(), width = 5, font = ("Times New Roman", 14))
+    btnSqrt.grid(row=4, column = 4, pady = 10)
 
-btnClr = tk.Button(window, text="Clear", command=lambda: clear(), width = 5, font = ("Times New Roman", 14))
-btnClr.grid(row=3, column = 5, pady = 10)
+    btnSqr = tk.Button(window, text="sqr", command=lambda: buttonPressSqu() , width = 5, font = ("Times New Roman", 14))
+    btnSqr.grid(row = 4, column = 5, pady = 10)
 
-btnTog = tk.Button(window, text="Tog", command=lambda: buttonPressToggle() , width = 5, font = ("Times New Roman", 14))
-btnTog.grid(row=4, column = 3, pady = 10)
+    btnEqu = tk.Button(window, text="=", command=lambda: calculate(), width = 20, font = ("Times New Roman", 14))
+    btnEqu.grid(row=4, column = 1, columnspan=2, pady = 10)
 
-btnSqrt = tk.Button(window, text="sqrt", command=lambda: buttonPressSqrt(), width = 5, font = ("Times New Roman", 14))
-btnSqrt.grid(row=4, column = 4, pady = 10)
-
-btnSqr = tk.Button(window, text="sqr", command=lambda: buttonPressSqu() , width = 5, font = ("Times New Roman", 14))
-btnSqr.grid(row = 4, column = 5, pady = 10)
-
-btnEqu = tk.Button(window, text="=", command=lambda: calculate(), width = 20, font = ("Times New Roman", 14))
-btnEqu.grid(row=4, column = 1, columnspan=2, pady = 10)
-
-window.mainloop()
+    window.mainloop()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+from GUI import GUI
+
+def main():
+    GUI.run()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. Created main.py in project root
2. Moved Tkinter startup code in gui/gui.py into a run() function
3. Updated imports so GUI can be launched via `python main.py`
4. No more 'import logic' confusion! It all works now as long as the project is run from 'main.py'
5. Also some very slight spacing adjustments in GUI.py